### PR TITLE
fix already released version and duplicated dependencies/plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <groupId>org.kie</groupId>
   <artifactId>kie-gwthelper-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>1.0</version>
+  <version>1.1-SNAPSHOT</version>
   <name>KIE :: Gwt Helper Maven Plugin</name>
   <description>Plugin to allow hot reload/SDM on GWT sources outside the current maven project - i.e.. in an arbitraryy location on filesystem</description>
   <url>https://github.com/kiegroup/kie-gwthelper-maven-plugin</url>
@@ -100,11 +100,6 @@
       <artifactId>maven-plugin-annotations</artifactId>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.maven.plugin-tools</groupId>
-      <artifactId>maven-plugin-annotations</artifactId>
-      <scope>provided</scope>
-    </dependency>
   </dependencies>
 
   <dependencyManagement>
@@ -124,11 +119,6 @@
         <artifactId>maven-plugin-annotations</artifactId>
         <version>${version.maven.artifact}</version>
         <scope>provided</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven.plugin-tools</groupId>
-        <artifactId>maven-plugin-annotations</artifactId>
-        <version>${version.maven.artifact}</version>
       </dependency>
       <dependency>
         <groupId>org.codehaus.plexus</groupId>


### PR DESCRIPTION
We already have released version 1.0 in Maven Central, but the latest tuning and externalizing from kiegroup/droolsjbpm-integration repository kept a outstanding things:

- master should have SNAPSHOT version
- release a 1.1 version to have available the latest content